### PR TITLE
update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,26 @@
 # docker-hubからOSのイメージ引込
-FROM centos:centos8.1.1911
+FROM centos:latest
 
 # サーバの日付合わせ
 RUN /bin/cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
 # epel-releaseのインストール
-RUN yum install -y epel-release &&\
-    yum clean all
+RUN dnf install -y epel-release &&\
+    dnf clean all
 
 # remiのインストール
 RUN rpm -ivh http://ftp.riken.jp/Linux/remi/enterprise/remi-release-8.rpm
 
 # yumのアップデート
-RUN yum update -y &&\
-    yum clean all
+RUN dnf update -y &&\
+    dnf clean all
 
 # 必要なモジュールのインストール(apache）
-RUN yum -y install httpd &&\
-    yum clean all
+RUN dnf -y install httpd &&\
+    dnf clean all
 
 # 必要なモジュールのインストール（php7.4）
-RUN yum -y install php74-php php74-php-mysqli php74-php-gd php74-php-mbstring php74-php-opcache php74-php-xml
+RUN dnf -y install php74-php php74-php-mysqli php74-php-gd php74-php-mbstring php74-php-opcache php74-php-xml php74-php-pear php74-php-devel php74-php-pecl-imagick php74-php-pecl-imagick-devel php74-php-pecl-zip
 
 # phpコマンドを作成
 RUN ln /usr/bin/php74 /usr/bin/php
@@ -28,12 +28,12 @@ RUN ln /usr/bin/php74 /usr/bin/php
 # wordpressインストールディレクトリの所有者をapacheユーザに変更                                              
 RUN chown -R apache:apache /var/www/html
 
-# ｐｈｐ７４−ｐｈｐ−ｆｐｍのサービス永続化
+# php74-php-fpmのサービス永続化
 RUN systemctl enable php74-php-fpm
 
 # apache サーバのサービス永続化
 RUN systemctl enable httpd 
 
 # 接続用ポートの穴あけ
-EXPOSE 80
+EXPOSE 80 443
 


### PR DESCRIPTION
Update: update Dockerfile

以下の点を修正。
- OSイメージ取得の際にバージョンを指定するのではなくlatestで最新を取得できるように修正。

- CentOS8を利用する前提なので、yumをやめdnfに変更

- HTTPSのポートを開放